### PR TITLE
Fix encoding error in swc loading.

### DIFF
--- a/audiomate/corpus/io/swc.py
+++ b/audiomate/corpus/io/swc.py
@@ -171,7 +171,7 @@ class SWCReader(base.CorpusReader):
         """
 
         meta_path = os.path.join(article_path, 'audiometa.txt')
-        with open(meta_path, 'r') as f:
+        with open(meta_path, 'r', encoding='utf-8') as f:
             content = f.read()
 
         name_match = READER_NAME_PATTERN.search(content)


### PR DESCRIPTION
Fixing "UnicodeDecodeError: 'ascii' codec can't decode byte ..." while loading swc dataset.